### PR TITLE
Added cramfs and VTO2000A support to extract.py

### DIFF
--- a/config_vto2000a.py
+++ b/config_vto2000a.py
@@ -1,0 +1,56 @@
+from enum import IntEnum
+from collections import OrderedDict
+
+class DAHUA_TYPE(IntEnum):
+	Plain = 1
+	uImage = 2
+	SquashFS = 4
+	CramFS = 8
+
+DAHUA_FILES = OrderedDict([
+	("Install", {
+		"required": True,
+		"type": DAHUA_TYPE.Plain
+	}),
+	("dm365_ubl_boot_16M.bin.img", {
+		"required": True,
+		"type": DAHUA_TYPE.Plain,
+		"size": 0x00030000
+	}),
+	("kernel-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.Plain,
+		"size": 0x000e0000
+	}),
+	("romfs-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.CramFS,
+		"size": 0x000e0000
+	}),
+	("user-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.SquashFS,
+		"size": 0x008c0000
+	}),
+	("web-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.CramFS,
+		"size": 0x00280000
+	}),
+	("data-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.CramFS,
+		"size": 0x008c0000
+	}),
+	("pd-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.CramFS,
+		"size": 0x00020000
+	}),
+	("custom-x.cramfs.img", {
+		"required": True,
+		"type": DAHUA_TYPE.uImage | DAHUA_TYPE.CramFS,
+		"size": 0x00020000
+	}),
+
+])


### PR DESCRIPTION
This PR:
- adds support to specify an alternative config file on command line (extract.py for now)
- adds VTO2000A sample config file
- adds cramfs support to extract.py
- uses subprocess.call instead of .run to make it compatible with python 3.4 that still runs on different OS as default, like Debian 8

Another PR for build will follow
